### PR TITLE
Fix error in jags.parallel() if R2jags is not attached

### DIFF
--- a/R/jagsParallel.R
+++ b/R/jagsParallel.R
@@ -61,7 +61,7 @@ jags.parallel <- function (data, inits, parameters.to.save, model.file = "model.
         return(jagsfit)
     }
     cl <- makeCluster(n.cluster, methods = FALSE)
-    clusterExport(cl, c(names(data), "mcmc", "mcmc.list", export_obj_names ), envir = envir)
+    clusterExport(cl, c(names(data), export_obj_names ), envir = envir)
     clusterSetRNGStream(cl, jags.seed)
     tryCatch(res <- clusterCall(cl, .runjags), finally = stopCluster(cl))
     result <- NULL


### PR DESCRIPTION
This PR simply changes this:

```r
clusterExport(cl, c(names(data), "mcmc", "mcmc.list", export_obj_names ), envir = envir)
```

to this:

```r
clusterExport(cl, c(names(data), export_obj_names ), envir = envir)
```

to fix #5. I am not sure why the GitHub diff is showing the whole file changed.