### PR TITLE
Allow number of chains and number of cores to be different in jags.parallel()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,17 @@
+^.*code-workspace
+^.*\.gcda$
+^.*\.gcno$
+^.*\.log$
+^.*\.out$
+^.*\.Rout$
+^.*\.Rproj$
+^\.DS_Store
+^\.git$
+^\.github$
+^\.gitignore$
+^\.lintr$
+^\.Rapp.history$
+^\.Rbuildignore$
+^\.Rhistory$
+^\.Rproj\.user$
+^_pkgdown\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,3 +11,4 @@ Imports: abind, coda (>= 0.13), graphics, grDevices, methods, R2WinBUGS, paralle
 SystemRequirements: JAGS (http://mcmc-jags.sourceforge.net)
 Description: Providing wrapper functions to implement Bayesian analysis in JAGS.  Some major features include monitoring convergence of a MCMC model using Rubin and Gelman Rhat statistics, automatically running a MCMC model till it converges, and implementing parallel processing of a MCMC model for multiple chains.
 License: GPL (> 2) 
+RoxygenNote: 7.1.1

--- a/R/jagsParallel.R
+++ b/R/jagsParallel.R
@@ -47,8 +47,9 @@ jags.parallel <- function (data, inits, parameters.to.save, model.file = "model.
 
 
 
-    .runjags <- function() {
+    .runjags <- function(seed) {
         requireNamespace("coda")
+        set.seed(seed)
         jagsfit <- jags(data = eval(expression(data)), inits = jags.inits,
             parameters.to.save = eval(expression(jags.params)),
             model.file = eval(expression(jags.model)), n.chains = 1,
@@ -62,8 +63,8 @@ jags.parallel <- function (data, inits, parameters.to.save, model.file = "model.
     }
     cl <- makeCluster(n.cluster, methods = FALSE)
     clusterExport(cl, c(names(data), "mcmc", "mcmc.list", export_obj_names ), envir = envir)
-    clusterSetRNGStream(cl, jags.seed)
-    tryCatch(res <- clusterCall(cl, .runjags), finally = stopCluster(cl))
+    seeds <- jags.seed + seq_len(n.chains)
+    tryCatch(res <- parLapply(cl = cl, X = seeds, fun = .runjags), finally = stopCluster(cl))
     result <- NULL
     model <- NULL
     for (ch in 1:n.chains) {

--- a/R2jags.Rproj
+++ b/R2jags.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(R2jags)
+
+test_check("R2jags")

--- a/tests/testthat/test-jags.parallel.R
+++ b/tests/testthat/test-jags.parallel.R
@@ -1,0 +1,26 @@
+test_that("fewer cores than chains", {
+  model <- "model {
+    for (i in 1:n) {
+      y[i] ~ dnorm(x[i] * beta, 1)
+    }
+    beta ~ dnorm(0, 1)
+  }"
+  model_file <- tempfile()
+  writeLines(model, model_file)
+  data <- list(
+    n = 10,
+    x = rnorm(10),
+    y = rnorm(10)
+  )
+  tmp <- capture.output(
+    out <- jags.parallel(
+      data,
+      parameters.to.save = "beta",
+      model.file = model_file,
+     n.chains = 4,
+     n.cluster = 2
+    )
+  )
+  expect_true(inherits(out, "rjags"))
+  expect_true(inherits(out$BUGSoutput, "bugs"))
+})

--- a/tests/testthat/test-jags.parallel.R
+++ b/tests/testthat/test-jags.parallel.R
@@ -17,10 +17,25 @@ test_that("fewer cores than chains", {
       data,
       parameters.to.save = "beta",
       model.file = model_file,
-     n.chains = 4,
-     n.cluster = 2
+      n.chains = 4,
+      n.cluster = 2
     )
   )
+  last_values_1 <- unlist(out$BUGSoutput$last.values)
+  expect_equal(length(unique(last_values_1)), 4L)
   expect_true(inherits(out, "rjags"))
   expect_true(inherits(out$BUGSoutput, "bugs"))
+  tmp <- capture.output(
+    out <- jags.parallel(
+      data,
+      parameters.to.save = "beta",
+      model.file = model_file,
+      n.chains = 4,
+      n.cluster = 2
+    )
+  )
+  last_values_2 <- unlist(out$BUGSoutput$last.values)
+  expect_true(inherits(out, "rjags"))
+  expect_true(inherits(out$BUGSoutput, "bugs"))
+  expect_equal(last_values_1, last_values_2)
 })


### PR DESCRIPTION
Fixes #4.

* Use `parLapply()` instead of `clusterCall()` in `jags.parallel()`. (Again, I am not sure why the GitHub diff shows the whole file changed. I only changed a couple lines.)
* Manage seeds on a chain-by-chain basis, not a core-by-core basis by pass the seed to `.runjags()`.
* Add a new `testthat` test (contributes to #1) to check that
    1.  `jags.parallel()` runs without error if `n.chains` is greater than `n.cluster`.
    2. `jags.parallel()` returns an output object of class `"rjags"` with a `BUGSoutput` object of class `"bugs"`.
    3. The last parameter draws differ across chains (so each chain got its own seed).
    4. The last parameter values are reproducible: repeated runs of `jags.parallel()` with the same seed produce identical sets of last values.