### PR TITLE
Add a `quiet` argument to jags()

### DIFF
--- a/R/jags.R
+++ b/R/jags.R
@@ -96,7 +96,7 @@ jags <- function( data, inits,
   if(!is.null(jags.module)){
     n.module <- length(jags.module)
     for(m in 1:n.module){
-        load.module(jags.module[m])
+        load.module(jags.module[m], quiet = quiet)
     }
   }
 

--- a/R/jags.R
+++ b/R/jags.R
@@ -12,7 +12,8 @@ jags <- function( data, inits,
                   progress.bar = "text",
                   digits = 5,
                   RNGname = c("Wichmann-Hill", "Marsaglia-Multicarry", "Super-Duper", "Mersenne-Twister"),
-                  jags.module = c("glm","dic")
+                  jags.module = c("glm","dic"),
+                  quiet = FALSE
                   )
 {
   #require( rjags )
@@ -152,7 +153,8 @@ jags <- function( data, inits,
                   data     = data,
                   inits    = init.values,
                   n.chains = n.chains,
-                  n.adapt  = 0 )
+                  n.adapt  = 0,
+                  quiet = quiet )
   #}
   adapt( m,
          n.iter         = n.adapt,

--- a/man/jags.Rd
+++ b/man/jags.Rd
@@ -24,7 +24,7 @@ jags(data, inits, parameters.to.save, model.file="model.bug",
   refresh = n.iter/50, progress.bar = "text", digits=5,
   RNGname = c("Wichmann-Hill", "Marsaglia-Multicarry",
               "Super-Duper", "Mersenne-Twister"),
-  jags.module = c("glm","dic")
+  jags.module = c("glm","dic"), quiet = FALSE
   )
 
 jags.parallel(data, inits, parameters.to.save, model.file = "model.bug",
@@ -107,7 +107,7 @@ jags2(data, inits, parameters.to.save, model.file="model.bug",
   \item{jags.module}{the vector of jags modules to be loaded.  Default are \dQuote{glm} and \dQuote{dic}. Input NULL if you don't want to load any jags module.}
   \item{export_obj_names}{character vector of objects to export to the clusters.}
   \item{envir}{default is .GlobalEnv}
-
+  \item{quiet}{Logical, whether to suppress stdout in \code{jags.model()}.}
 }
 
 


### PR DESCRIPTION
This PR adds a `quiet` argument to `jags()` to suppress output from `rjags::jags.model()`. The following code no longer writes to stdout.

```r
  model <- "model {
    for (i in 1:n) {
      y[i] ~ dnorm(x[i] * beta, 1)
    }
    beta ~ dnorm(0, 1)
  }"
  model_file <- tempfile()
  writeLines(model, model_file)
  data <- list(
    n = 10,
    x = rnorm(10),
    y = rnorm(10)
  )
  out <- R2jags::jags(
    data,
    parameters.to.save = "beta",
    model.file = model_file,
    n.chains = 4,
    quiet = TRUE,
    progress.bar = "none"
  )
```
