### PR TITLE
Fix error loading JAGS modules if jags.module is character(0)

### DIFF
--- a/R/jags.R
+++ b/R/jags.R
@@ -93,9 +93,9 @@ jags <- function( data, inits,
 
 
   #load.module("lecuyer")
-  if(!is.null(jags.module)){
+  if(length(jags.module) > 0L) {
     n.module <- length(jags.module)
-    for(m in 1:n.module){
+    for(m in seq_len(n.module)) {
         load.module(jags.module[m], quiet = quiet)
     }
   }


### PR DESCRIPTION
This pull request fixes #12 using a couple minor adjustments to help `R2jags::jags()` tolerate a non-null `jags.model` argument of length 0.