### PR TITLE
Crucial fix of bug in jags.R function + rename pD to pV

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+2024-06-22 Gianluca Baio <g.baio@ucl.ac.uk>
+   * DESCRIPTION (Date): 2024-06-22
+   * DESCRIPTION (Authors): Add GB's contributions
+   * R/jags.R: Fix a major bug. Currently, there's effectively no burnin phase, because what is 
+     supposed to be that, is just an adaptation phase, which doesn't store the burnin samples.
+     Thus, at present, the saved simulations may not be after convergence, with the undesired
+     effect that some model actually haven't converged. In addition, changes the terminology
+     and rename the object 'pD' to 'pV' (because the default JAGS computation is that...).
+     Also, adds the possibility of computing the proper 'pD', via 'rjags::dic.samples()'
+   * R/jags.sims.R: Matches the renaming of 'pD' into 'pV', throughout.
+   * R/print.R: Matches the renaming of 'pD' into 'pV', throughout and adds the possibility
+     of printing the value of 'pD' too, if it's added to the JAGS object
+   * man/jags.Rd: update with three new options
+
 2024-05-4  Yu-Sung Su     <suyusung@tsinghua.edu.cn>
     * DESCRIPTION (Version, Date): 0.8-5
     * incorporate patches suggested by CRAN

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,16 @@
 Package: R2jags
 Version: 0.8-5
-Date: 2024-05-01
+Date: 2024-06-22
 Title: Using R to Run 'JAGS'
 Authors@R: c(person("Yu-Sung", "Su", role =  c("aut", "cre"), 
 		email = "suyusung@tsinghua.edu.cn", 
 		comment = c(ORCID = "0000-0001-5021-8209")),
-	     person("Masanao", "Yajima", email = "yajima@bu.edu", role = "aut")
+	     person("Masanao", "Yajima", email = "yajima@bu.edu", role = "aut"),
+	     person("Gianluca", "Baio", email="g.baio@ucl.ac.uk", role="ctb")
 		)
 Author: Yu-Sung Su [aut, cre] (<https://orcid.org/0000-0001-5021-8209>),
         Masanao Yajima [aut]
+        Gianluca Baio [ctb]
 Maintainer: Yu-Sung Su <suyusung@tsinghua.edu.cn>
 BugReports: https://github.com/suyusung/R2jags/issues/
 Depends: R (>= 2.14.0), rjags (>= 3-3)

--- a/R/as.bugs.array2.R
+++ b/R/as.bugs.array2.R
@@ -181,14 +181,21 @@ as.bugs.array2 <- function(sims.array, model.file=NULL, program="jags",
   if(DIC && is.null(DICOutput)) { ## calculate DIC from deviance
     deviance <- all$sims.array[, , "deviance", drop = FALSE]
     dim(deviance) <- dim(deviance)[1:2]
-    pD <- numeric(n.chains)
+# Modified by GB to rename pD to pV
+    pV <- numeric(n.chains)
     DIC <- numeric(n.chains)
     for (i in 1:n.chains) {
-      pD[i] <- var(deviance[, i])/2
-      DIC[i] <- mean(deviance[, i]) + pD[i]
+      pV[i] <- var(deviance[, i])/2
+      DIC[i] <- mean(deviance[, i]) + pV[i]
     }
-    all <- c(all, list(isDIC=TRUE, DICbyR=TRUE,  pD=mean(pD), DIC=mean(DIC)))
+    all <- c(all, list(isDIC=TRUE, DICbyR=TRUE,  pV=mean(pV), DIC=mean(DIC)))
   }
+  #' GB: This is ported by R2WinBUGS/R2OpenBUGS and assumes that the model
+  #' is actually run using BUGS, which would mean you can actually compute
+  #' pD using BUGS output. In this case, because 'DICOutput' is set to 'NULL'
+  #' this bit is kind of ignored. But the drawback is that the only possibility
+  #' to compute pD is to go through 'rjags::dic.samples()'. I have added an
+  #' optional call to 'rjags::dic.samples' in 'jags' to compute pD
   else if(DIC && !is.null(DICOutput)) { ## use DIC from BUGS
     all <- c(all, list(isDIC=TRUE, DICbyR=FALSE,
                        pD=DICOutput[nrow(DICOutput),4],

--- a/R/jags.R
+++ b/R/jags.R
@@ -9,7 +9,7 @@ jags <- function( data, inits,
                   DIC          = TRUE,
                   pD           = FALSE,
                   n.iter.pd    = NULL,
-                  n.adapt      = 0,
+                  n.adapt      = 100,
                   working.directory = NULL,
                   jags.seed    = 123,
                   refresh      = n.iter/50,
@@ -148,8 +148,11 @@ jags <- function( data, inits,
                   data     = data,
                   inits    = init.values,
                   n.chains = n.chains,
-                  n.adapt  = n.adapt,
+                  n.adapt  = 0,
                   quiet = quiet )
+  
+  # Adds adaptation, just in case...
+  adapt(m,n.iter=n.adapt,end.adaptation=TRUE)
 
   # Updates the model for the burning phase
   rjags:::update.jags(

--- a/R/jags.R
+++ b/R/jags.R
@@ -152,7 +152,7 @@ jags <- function( data, inits,
                   quiet = quiet )
   
   # Adds adaptation, just in case...
-  adapt(m,n.iter=n.adapt,end.adaptation=TRUE)
+  adapt(m,n.iter=n.adapt,progress.bar=progress.bar,quiet=quiet,end.adaptation=TRUE)
 
   # Updates the model for the burning phase
   rjags:::update.jags(

--- a/R/jags.sims.R
+++ b/R/jags.sims.R
@@ -145,13 +145,14 @@ jags.sims <- function (parameters.to.save, n.chains, n.iter, n.burnin, n.thin, D
     deviance <- all$sims.array[, , "deviance", drop = FALSE]
     dimnames(deviance) <- NULL
     dim(deviance) <- dim(deviance)[1:2]
-    pD <- numeric(n.chains)
+# Modified by GB to change pD to pV
+    pV <- numeric(n.chains)
     DIC <- numeric(n.chains)
     for (i in 1:n.chains) {
-      pD[i] <- var(deviance[, i])/2
-      DIC[i] <- mean(deviance[, i]) + pD[i]
+      pV[i] <- var(deviance[, i])/2
+      DIC[i] <- mean(deviance[, i]) + pV[i]
     }
-    all <- c(all, list(isDIC = TRUE, DICbyR = TRUE, pD = mean(pD),
+    all <- c(all, list(isDIC = TRUE, DICbyR = TRUE, pV = mean(pV),
                 DIC = mean(DIC)))
   }
   else {

--- a/R/print.R
+++ b/R/print.R
@@ -36,16 +36,23 @@ print.rjags <- function(x, digits = 3,
       cat("\nFor each parameter, n.eff is a crude measure of effective sample size,")
       cat("\nand Rhat is the potential scale reduction factor (at convergence, Rhat=1).\n")
   }
+  #' GB: Can modify this to correctly report the penalty as 'pV', which it is.
+  #' In reality, there's no need for the multiple option (which would compute
+  #' pD as BUGS does), because, JAGS doesn't do that...
   if (x$isDIC) {
-      msgDICRule <- ifelse(x$DICbyR, "(using the rule, pD = var(deviance)/2)", 
+      msgDICRule <- ifelse(x$DICbyR, "(using the rule: pV = var(deviance)/2)",
           "(using the rule, pD = Dbar-Dhat)")
       cat(paste("\nDIC info ", msgDICRule, "\n", sep = ""))
       if (length(x$DIC) == 1) {
-          cat("pD =", fround(x$pD, 1), "and DIC =", fround(x$DIC, 
-              1))
+          cat("pV =", fround(x$pV, 1), "and DIC =", fround(x$DIC, 1))
       }
       else if (length(x$DIC) > 1) {
           print(round(x$DIC, 1))
+      }
+      #' GB: If pD has also been monitored, then print it alongside pV
+      if (!is.null(x$pD)) {
+        cat("\nDIC info (using the rule: pD = Dbar-Dhat, computed via 'rjags::dic.samples')")
+        cat(paste("\npD =", fround(x$pD, 1), "and DIC =", fround(x$DIC2, 1)))
       }
       cat("\nDIC is an estimate of expected predictive error (lower deviance is better).\n")
   }

--- a/R/print.R
+++ b/R/print.R
@@ -30,7 +30,7 @@ print.rjags <- function(x, digits = 3,
       x$n.burnin, " discarded)", sep = "")
   if (x$n.thin > 1) 
       cat(", n.thin =", x$n.thin)
-  cat("\n n.sims =", x$n.sims, "iterations saved. Running time =",x$time2run," secs\n")
+  cat("\n n.sims =", x$n.sims, "iterations saved. Running time =",x$time2run,"secs\n")
   print(round(summaryMatrix, digits), ...)
   if (x$n.chains > 1) {
       cat("\nFor each parameter, n.eff is a crude measure of effective sample size,")

--- a/R/print.R
+++ b/R/print.R
@@ -30,7 +30,7 @@ print.rjags <- function(x, digits = 3,
       x$n.burnin, " discarded)", sep = "")
   if (x$n.thin > 1) 
       cat(", n.thin =", x$n.thin)
-  cat("\n n.sims =", x$n.sims, "iterations saved. Running time =",x$time2run,"secs"\n")
+  cat("\n n.sims =", x$n.sims, "iterations saved. Running time =",x$time2run," secs\n")
   print(round(summaryMatrix, digits), ...)
   if (x$n.chains > 1) {
       cat("\nFor each parameter, n.eff is a crude measure of effective sample size,")

--- a/R/print.R
+++ b/R/print.R
@@ -30,7 +30,7 @@ print.rjags <- function(x, digits = 3,
       x$n.burnin, " discarded)", sep = "")
   if (x$n.thin > 1) 
       cat(", n.thin =", x$n.thin)
-  cat("\n n.sims =", x$n.sims, "iterations saved\n")
+  cat("\n n.sims =", x$n.sims, "iterations saved. Running time =",x$time2run,"secs"\n")
   print(round(summaryMatrix, digits), ...)
   if (x$n.chains > 1) {
       cat("\nFor each parameter, n.eff is a crude measure of effective sample size,")

--- a/man/jags.Rd
+++ b/man/jags.Rd
@@ -91,7 +91,7 @@ jags2(data, inits, parameters.to.save, model.file="model.bug",
   \item{n.iter.pd}{number of iterations to feed 'rjags::dic.samples()' to
     compute 'pD'. Defaults at 1000.}
   \item{n.adapt}{number of iterations for which to run the adaptation, when
-    creating the model object. Defaults at 0 (which means no adaptation).}
+    creating the model object. Defaults at 100.}
   \item{working.directory}{sets working directory during execution of
     this function; This should be the directory where model file is.}
   \item{jags.seed}{random seed for \code{JAGS}, default is 123.  This function is used for jags.parallell() and does not work for jags().  Use set.seed() instead if you want to produce identical result with jags() }.

--- a/man/jags.Rd
+++ b/man/jags.Rd
@@ -85,6 +85,13 @@ jags2(data, inits, parameters.to.save, model.file="model.bug",
 %          iterations and then the adaptive mode is switched off.}
   \item{DIC}{logical; if \code{TRUE} (default), compute deviance, pD,
     and DIC. The rule \code{pD=var(deviance) / 2} is used.}
+  \item{pD}{logical; if \code{TRUE} and \code{DIC} is also \code{TRUE}, then
+    adds the computation of 'pD', using 'rjags::dic.samples()'. Defaults to
+    \code{FALSE}.}
+  \item{n.iter.pd}{number of iterations to feed 'rjags::dic.samples()' to
+    compute 'pD'. Defaults at 1000.}
+  \item{n.adapt}{number of iterations for which to run the adaptation, when
+    creating the model object. Defaults at 0 (which means no adaptation).}
   \item{working.directory}{sets working directory during execution of
     this function; This should be the directory where model file is.}
   \item{jags.seed}{random seed for \code{JAGS}, default is 123.  This function is used for jags.parallell() and does not work for jags().  Use set.seed() instead if you want to produce identical result with jags() }.
@@ -134,7 +141,8 @@ jags2(data, inits, parameters.to.save, model.file="model.bug",
 
 \author{
   Yu-Sung Su \email{suyusung@tsinghua.edu.cn},
-  Masanao Yajima \email{yajima@bu.edu}
+  Masanao Yajima \email{yajima@bu.edu},
+  Gianluca Baio \email{g.baio@ucl.ac.uk}
 }
 
 


### PR DESCRIPTION
I think I found a crucial bug in `jags.R`; after creating the JAGS object (via `jags.model`), the current code proceeds to an adaptation phase (via `rjags::adapt`). But this doesn't store the simulations and so, effectively, there is no burnin considered in a `R2jags` run. For some models this is a problem because the resulting simulations are not at convergence and so they show massive variance in the node `deviance` (with typically a handful of outlier, with very large values). Other monitored notes may also show this artificial problem.

Also, I have renamed the variable `pD` to `pV`, because that's effectively what it is, in the JAGS computation (= var(deviance)/2). I have also added the possibility of computing the "proper" `pD`, via a call to `rjags::dic.samples()` and then modified the `print` method.

I have done some tests and, for the model that was showing problems, now `R2jags` works and give the correct results. The table and objects generated by `jags.R` are OK with the change in notation for `pD`/`pV`.