### PR TITLE
Rebased with current changes in 'master' + update 'jags.R' to make the adaption phase silent + update jags documentation with example on pD

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install jags (windows-latest)
         if: runner.os == 'Windows'
         run: |
-          curl.exe -o wjags.exe --url https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.2.0-Rtools33.exe
+          curl.exe -o wjags.exe --url https://deac-fra.dl.sourceforge.net/project/mcmc-jags/JAGS/4.x/Windows/JAGS-4.2.0-Rtools33.exe
           wjags.exe /S
           del wjags.exe
         shell: cmd
@@ -64,7 +64,6 @@ jobs:
       - name: Install jags (macOS-latest)
         if: runner.os == 'macOS'
         run : |
-          rm '/usr/local/bin/gfortran'
           brew install jags
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -63,8 +63,7 @@ jobs:
         # Install JAGS on Mac OS
       - name: Install jags (macOS-latest)
         if: runner.os == 'macOS'
-        run : |
-          brew install jags
+        run : brew install pkg-config; brew install jags
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install jags (windows-latest)
         if: runner.os == 'Windows'
         run: |
-          curl.exe -o wjags.exe --url https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.2.0-Rtools33.exe/download
+          curl.exe -o wjags.exe --url https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.2.0-Rtools33.exe
           wjags.exe /S
           del wjags.exe
         shell: cmd
@@ -63,7 +63,9 @@ jobs:
         # Install JAGS on Mac OS
       - name: Install jags (macOS-latest)
         if: runner.os == 'macOS'
-        run : brew install jags
+        run : |
+          rm '/usr/local/bin/gfortran'
+          brew install jags
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -1,0 +1,75 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, bmhta]
+  pull_request:
+    branches: [main, bmhta]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      RSPM: ${{ matrix.config.rspm }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-pandoc@v2
+      
+      - name: Double check repos
+        run: |
+          print(getOption("repos"))
+        shell: Rscript {0}
+
+#      - name: Install JAGS
+#        run: |
+#          sudo apt-get update -y
+#          sudo apt-get install -y jags
+
+        # Downloads the latest version of JAGS exe file
+      - name: Install jags (windows-latest)
+        if: runner.os == 'Windows'
+        run: |
+          curl.exe -o wjags.exe --url https://sourceforge.net/projects/mcmc-jags/files/latest/download
+          wjags.exe /S
+          del wjags.exe
+        shell: cmd
+
+        # Install JAGS on Mac OS
+      - name: Install jags (macOS-latest)
+        if: runner.os == 'macOS'
+        run : brew install jags
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"all"'
+          extra-packages: |
+             rcmdcheck
+          
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -50,11 +50,12 @@ jobs:
 #          sudo apt-get update -y
 #          sudo apt-get install -y jags
 
-        # Downloads the latest version of JAGS exe file
+        # Downloads the version of JAGS exe file linked to Rtools, which is necessary to run the check
+        # See: https://forum.posit.co/t/check-standard-yaml-fails-to-install-system-dependencies-on-macos-and-windows/89393/3
       - name: Install jags (windows-latest)
         if: runner.os == 'Windows'
         run: |
-          curl.exe -o wjags.exe --url https://sourceforge.net/projects/mcmc-jags/files/latest/download
+          curl.exe -o wjags.exe --url https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Windows/JAGS-4.2.0-Rtools33.exe/download
           wjags.exe /S
           del wjags.exe
         shell: cmd

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -58,6 +58,7 @@ jobs:
           curl.exe -o wjags.exe --url https://deac-fra.dl.sourceforge.net/project/mcmc-jags/JAGS/4.x/Windows/JAGS-4.2.0-Rtools33.exe
           wjags.exe /S
           del wjags.exe
+          jags
         shell: cmd
 
         # Install JAGS on Mac OS

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ vignettes/*.pdf
 *.db-journal
 .svn/wc.db
 .svn/format
+.github

--- a/R/jags.R
+++ b/R/jags.R
@@ -156,8 +156,10 @@ jags <- function( data, inits,
                   n.adapt  = 0,
                   quiet = quiet )
   
-  # Adds adaptation, just in case...
-  adapt(m,n.iter=n.adapt,progress.bar=progress.bar,quiet=quiet,end.adaptation=TRUE)
+  # Adds adaptation. This never needs to be verbose, so force
+  # 'progress.bar' to 'none' and 'quiet' to TRUE, irrespective of what the
+  # global values for these options are in the function
+  adapt(m,n.iter=n.adapt,progress.bar="none",quiet=TRUE,end.adaptation=TRUE)
 
   # Updates the model for the burning phase
   .update.jags(   

--- a/man/jags.Rd
+++ b/man/jags.Rd
@@ -231,18 +231,18 @@ jags2(data, inits, parameters.to.save, model.file="model.bug",
   jagsfit <- jags(data=jags.data, inits=jags.inits, jags.params,
     n.iter=5000, model.file=model.file)
 
+  # Can also compute the DIC using pD (=Dbar-Dhat), via dic.samples(), which
+  # is a closer approximation to the original formulation of Spiegelhalter et
+  # al (2002), instead of pV (=var(deviance)/2), which is the default in JAGS
+   jagsfit.pD <- jags.parallel(data=jags.data, inits=jags.inits, jags.params,
+     n.iter=5000, model.file=model.file, pD=TRUE)
+
   # Run jags parallely, no progress bar. R may be frozen for a while,
   # Be patient. Currenlty update afterward does not run parallelly
   #
    jagsfit.p <- jags.parallel(data=jags.data, inits=jags.inits, jags.params,
      n.iter=5000, model.file=model.file)
   
-  # Can also compute the DIC using pD (=Dbar-Dhat), via dic.samples(), which
-  # is a closer approximation to the original formulation of Spiegelhalter et
-  # al (2002), instead of pV (=var(deviance)/2), which is the default in JAGS
-   jagsfit.p <- jags.parallel(data=jags.data, inits=jags.inits, jags.params,
-     n.iter=5000, model.file=model.file, pD=TRUE)
-
   # display the output
   print(jagsfit)
   plot(jagsfit)

--- a/man/jags.Rd
+++ b/man/jags.Rd
@@ -234,7 +234,7 @@ jags2(data, inits, parameters.to.save, model.file="model.bug",
   # Can also compute the DIC using pD (=Dbar-Dhat), via dic.samples(), which
   # is a closer approximation to the original formulation of Spiegelhalter et
   # al (2002), instead of pV (=var(deviance)/2), which is the default in JAGS
-   jagsfit.pD <- jags.parallel(data=jags.data, inits=jags.inits, jags.params,
+   jagsfit.pD <- jags(data=jags.data, inits=jags.inits, jags.params,
      n.iter=5000, model.file=model.file, pD=TRUE)
 
   # Run jags parallely, no progress bar. R may be frozen for a while,

--- a/man/jags.Rd
+++ b/man/jags.Rd
@@ -236,6 +236,12 @@ jags2(data, inits, parameters.to.save, model.file="model.bug",
   #
    jagsfit.p <- jags.parallel(data=jags.data, inits=jags.inits, jags.params,
      n.iter=5000, model.file=model.file)
+  
+  # Can also compute the DIC using pD (=Dbar-Dhat), via dic.samples(), which
+  # is a closer approximation to the original formulation of Spiegelhalter et
+  # al (2002), instead of pV (=var(deviance)/2), which is the default in JAGS
+   jagsfit.p <- jags.parallel(data=jags.data, inits=jags.inits, jags.params,
+     n.iter=5000, model.file=model.file, pD=TRUE)
 
   # display the output
   print(jagsfit)


### PR DESCRIPTION
I have implemented only minor changes, incrementally on your current `master`. The others I discuss in #19 are still on the table, if you're interested. I have a local fork where I have added the global options (via `.onLoad`) to setup the progress bar and whether the run should be quiet or not (setting `text` and `FALSE` by default, but the user could change these globally by re-setting `options(r2j.pb="text")`, for instance...  