### PR TITLE
Allow for burnin set to 0

### DIFF
--- a/R/jags.R
+++ b/R/jags.R
@@ -164,7 +164,7 @@ jags <- function( data, inits,
   # Updates the model for the burning phase
   .update.jags(   
     m,
-    n.iter=n.burnin,
+    n.iter=max(n.burnin,1000),
     n.thin=n.thin,
     by=refresh,
     progress.bar=progress.bar

--- a/R/jags.R
+++ b/R/jags.R
@@ -164,7 +164,7 @@ jags <- function( data, inits,
   # Updates the model for the burning phase
   .update.jags(   
     m,
-    n.iter=max(n.burnin,1000),
+    n.iter=max(n.burnin,(n.iter/2)),
     n.thin=n.thin,
     by=refresh,
     progress.bar=progress.bar


### PR DESCRIPTION
I think if you haven't submitted to CRAN, this would be helpful --- the revised `jags.R` function basically doesn't allow for `n.burnin=0`, because the preliminary `update` step is based on setting the number of iterations for the warmup period to the selected `n.burnin`, which by default is positive, but if set to 0, will break the code.

I've changed to `max(n.burnin, (n.iter/2))` so that if `n.burnin` is 0 the `update` stage still happens.